### PR TITLE
fix(handlers): restart kubelet for each kubelet configuration change

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Kubernetes | Restart Kubelet
+- name: Kubernetes | Perform a daemon reload and restart Kubelet
   systemd:
     state: restarted
     name: kubelet.service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
     dest: "{{ kubelet_systemd_unit }}"
     force: yes
   loop: "{{ lookup('url', kubelet_systemd_unit_url, split_lines=False, wantlist=True )}}"
+  notify: "restart kubelet"
 
 - name: Kubernetes | Get Kubeadm drop-in file
   copy:
@@ -34,10 +35,12 @@
     dest: "{{ kubeadm_systemd_dropin_file }}"
     force: yes
   loop: "{{ lookup('url', kubeadm_systemd_dropin_url, split_lines=False, wantlist=True )}}"
+  notify: "restart kubelet"
 
-- name: Kubernetes | Ensure Kubelet is running
+- meta: flush_handlers
+
+- name: Kubernetes | Ensure Kubelet is enabled and running
   systemd:
     state: started
     name: kubelet.service
-    daemon_reload: yes
     enabled: yes


### PR DESCRIPTION
We make sure kubelet gets restarted when updating kubelet units or drop-in.
Also prevents unneeded daemon-reload that was inducing a systematic changed state
in ansible (thanks to flush_handlers meta).